### PR TITLE
Add error message for shape mismatch

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -198,6 +198,7 @@ def make_test(name, problem, problem_spec, add_sizes=[], constraint=lambda d: d)
 
         out2 = problem(*map(tensor, d.values()))
         out = tensor(out)
+        assert out.shape == out2.shape, f"Two tensors have different shape\n Spec: \n\tExpect: {out.shape} \n\tGot: {out2.shape}"
         out2 = torch.broadcast_to(out2, out.shape)
         assert torch.allclose(
             out, out2

--- a/lib.py
+++ b/lib.py
@@ -198,8 +198,10 @@ def make_test(name, problem, problem_spec, add_sizes=[], constraint=lambda d: d)
 
         out2 = problem(*map(tensor, d.values()))
         out = tensor(out)
-        assert out.shape == out2.shape, f"Two tensors have different shape\n Spec: \n\tExpect: {out.shape} \n\tGot: {out2.shape}"
-        out2 = torch.broadcast_to(out2, out.shape)
+        try:
+            out2 = torch.broadcast_to(out2, out.shape)
+        except RuntimeError:
+            assert out.shape == out2.shape, f"Two tensors have different shape\n Spec: \n\tExpect: {out.shape} \n\tGot: {out2.shape}"
         assert torch.allclose(
             out, out2
         ), "Two tensors are not equal\n Spec: \n\t%s \n\t%s" % (out, out2)


### PR DESCRIPTION
Address for #14 , catch the shape mismatch before PyTorch throws `RuntimeError`.
Returns an error message as below:
```
AssertionError: Two tensors have a different shapes
 Spec: 
	Expect: torch.Size([5]) 
	Got: torch.Size([1, 5])
```
