### PR TITLE
Switch order of compress and pad_to, make styling more concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,37 @@ test_flip = make_test("flip", flip, flip_spec, add_sizes=["i"])
 # run_test(test_flip)
 ```
 
-## Puzzle 12 - compress
+## Puzzle 12 - pad_to
+
+
+Compute pad_to - eliminate or add 0s to change size of vector.
+
+
+```python
+def pad_to_spec(a, out):
+    for i in range(min(len(out), len(a))):
+        out[i] = a[i]
+
+
+def pad_to(a: TT["i"], i: int, j: int) -> TT["j"]:
+    raise NotImplementedError
+
+
+test_pad_to = make_test("pad_to", pad_to, pad_to_spec, add_sizes=["i", "j"])
+```
+
+
+    
+![svg](Tensor%20Puzzlers_files/Tensor%20Puzzlers_47_0.svg)
+    
+
+
+
+```python
+# run_test(test_pad_to)
+```
+
+## Puzzle 13 - compress
 
 
 Compute [compress](https://numpy.org/doc/stable/reference/generated/numpy.compress.html) - keep only masked entries (left-aligned).
@@ -458,36 +488,6 @@ test_compress = make_test("compress", compress, compress_spec, add_sizes=["i"])
 
 ```python
 # run_test(test_compress)
-```
-
-## Puzzle 13 - pad_to
-
-
-Compute pad_to - eliminate or add 0s to change size of vector.
-
-
-```python
-def pad_to_spec(a, out):
-    for i in range(min(len(out), len(a))):
-        out[i] = a[i]
-
-
-def pad_to(a: TT["i"], i: int, j: int) -> TT["j"]:
-    raise NotImplementedError
-
-
-test_pad_to = make_test("pad_to", pad_to, pad_to_spec, add_sizes=["i", "j"])
-```
-
-
-    
-![svg](Tensor%20Puzzlers_files/Tensor%20Puzzlers_47_0.svg)
-    
-
-
-
-```python
-# run_test(test_pad_to)
 ```
 
 ## Puzzle 14 - sequence_mask

--- a/Tensor Puzzlers.ipynb
+++ b/Tensor Puzzlers.ipynb
@@ -1567,19 +1567,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6c1517a4119f7045",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "## Puzzle 12 - pad_to\n",
     "\n",
     "\n",
     "Compute pad_to - eliminate or add 0s to change size of vector."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "6c1517a4119f7045"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ae9bf2c156964e0a",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "def pad_to_spec(a, out):\n",
@@ -1592,35 +1603,38 @@
     "\n",
     "\n",
     "test_pad_to = make_test(\"pad_to\", pad_to, pad_to_spec, add_sizes=[\"i\", \"j\"])"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "ae9bf2c156964e0a"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c5be502f294385f4",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "# run_test(test_pad_to)"
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "c5be502f294385f4"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "5b4ab83cd83cc3",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "## Puzzle 13 - compress\n",
     "\n",
     "\n",
     "Compute [compress](https://numpy.org/doc/stable/reference/generated/numpy.compress.html) - keep only masked entries (left-aligned)."
-   ],
-   "metadata": {
-    "collapsed": false
-   },
-   "id": "5b4ab83cd83cc3"
+   ]
   },
   {
    "cell_type": "code",
@@ -2250,12 +2264,27 @@
     "def repeat(a: TT[\"i\"], d: TT[1]) -> TT[\"d\", \"i\"]:\n",
     "    raise NotImplementedError\n",
     "\n",
-    "test_repeat = make_test(\"repeat\", repeat, repeat_spec, constraint=constraint_set)\n",
+    "test_repeat = make_test(\"repeat\", repeat, repeat_spec, constraint=constraint_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4633aa19-3b1b-46fa-a8de-d9644017d212",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(test_repeat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48faa010-3410-4c56-97a7-a8c3cffe31ec",
+   "metadata": {},
+   "source": [
+    "## Puzzle 21 - bucketize\n",
     "\n",
-    "\n",
-    "# ## Puzzle 21 - bucketize\n",
-    "#\n",
-    "# Compute [bucketize](https://pytorch.org/docs/stable/generated/torch.bucketize.html)"
+    "Compute [bucketize](https://pytorch.org/docs/stable/generated/torch.bucketize.html)"
    ]
   },
   {
@@ -2318,11 +2347,27 @@
     "test_bucketize = make_test(\"bucketize\", bucketize, bucketize_spec,\n",
     "                           constraint=constraint_set)\n",
     "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb653685-584e-4766-8f7e-022bbc548585",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(test_bucketize)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab451e9e-ace5-40b7-b711-cb602cf9c91a",
+   "metadata": {},
+   "source": [
+    "## Speed Run Mode!\n",
     "\n",
-    "#\n",
-    "# # Speed Run Mode!\n",
-    "#\n",
-    "# What is the smallest you can make each of these?"
+    "What is the smallest you can make each of these?"
    ]
   },
   {
@@ -2381,9 +2426,9 @@
    "cell_metadata_filter": "id,-all"
   },
   "kernelspec": {
-   "display_name": "tensor_puzzles",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "tensor_puzzles"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2395,7 +2440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/Tensor Puzzlers.ipynb
+++ b/Tensor Puzzlers.ipynb
@@ -1567,14 +1567,60 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa4469eb",
-   "metadata": {},
    "source": [
-    "## Puzzle 12 - compress\n",
+    "## Puzzle 12 - pad_to\n",
+    "\n",
+    "\n",
+    "Compute pad_to - eliminate or add 0s to change size of vector."
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6c1517a4119f7045"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "def pad_to_spec(a, out):\n",
+    "    for i in range(min(len(out), len(a))):\n",
+    "        out[i] = a[i]\n",
+    "\n",
+    "\n",
+    "def pad_to(a: TT[\"i\"], i: int, j: int) -> TT[\"j\"]:\n",
+    "    raise NotImplementedError\n",
+    "\n",
+    "\n",
+    "test_pad_to = make_test(\"pad_to\", pad_to, pad_to_spec, add_sizes=[\"i\", \"j\"])"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "ae9bf2c156964e0a"
+  },
+  {
+   "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "# run_test(test_pad_to)"
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "c5be502f294385f4"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Puzzle 13 - compress\n",
     "\n",
     "\n",
     "Compute [compress](https://numpy.org/doc/stable/reference/generated/numpy.compress.html) - keep only masked entries (left-aligned)."
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "5b4ab83cd83cc3"
   },
   {
    "cell_type": "code",
@@ -1645,85 +1691,6 @@
    "outputs": [],
    "source": [
     "# run_test(test_compress)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e944d79",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "source": [
-    "## Puzzle 13 - pad_to\n",
-    "\n",
-    "\n",
-    "Compute pad_to - eliminate or add 0s to change size of vector."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "id": "52988720",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-07-13T00:15:30.064726Z",
-     "iopub.status.busy": "2022-07-13T00:15:30.064418Z",
-     "iopub.status.idle": "2022-07-13T00:15:31.162878Z",
-     "shell.execute_reply": "2022-07-13T00:15:31.162268Z"
-    },
-    "id": "-DsZHgOTroVN"
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:ev=\"http://www.w3.org/2001/xml-events\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" baseProfile=\"full\" height=\"300.0179999999999\" version=\"1.1\" width=\"1020\"><defs><marker id=\"arrow\" markerHeight=\"3.5\" markerWidth=\"5\" orient=\"auto\" refX=\"5.0\" refY=\"1.7\"><polygon points=\"0,0 5,1.75 0,3.5\"/></marker></defs><g style=\"fill:white;\"><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 510.00299999999993, 150.00899999999996)\"><g transform=\"matrix(47.61904761904761, 0.0, 0.0, 47.61904761904761, 0.0, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -0.0, 2.220446049250313e-16)\"><g><g style=\"fill: #ffffff;stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"6.000359999999999\" style=\"vector-effect: non-scaling-stroke;\" width=\"20.40012\" x=\"-10.20006\" y=\"-3.0001799999999994\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -1.7763568394002505e-15, -2.4001799999999998)\"><g><g><g><g><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.5)\"><g style=\"fill: #000000;stroke: black;stroke-width: 0.0;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><text style=\"text-align:center; text-anchor:middle; dominant-baseline:middle;\n",
-       "                      font-family:sans-serif; font-weight: bold;\n",
-       "                      font-size:0.75px;\n",
-       "                      vector-effect: non-scaling-stroke;\" transform=\"translate(-5e-05, 0)\">pad_to</text></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 1.0001)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 3.0001999999999995)\"><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -8.5, -1.0000499999999999)\"><g><g><g><g><g><g><g><g><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -5e-05, -0.25005)\"><g><g><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.25)\"><g style=\"fill: #000000;stroke: black;stroke-width: 0.0;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><text style=\"text-align:center; text-anchor:middle; dominant-baseline:middle;\n",
-       "                      font-family:sans-serif; font-weight: bold;\n",
-       "                      font-size:0.5px;\n",
-       "                      vector-effect: non-scaling-stroke;\" transform=\"translate(-5e-05, 0)\">a</text></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.5001)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g></g><g/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.50005, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.50005, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -1.0, -0.0)\"><g><g><g><g><g style=\"fill: #0000ff;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.0, 0.0)\"><g style=\"fill: #0000ff;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.0, 0.0)\"><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g></g><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 6.50005, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 9.50005, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -1.5, -0.0)\"><g><g><g><g><g><g><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.5800000000000001;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.0, 0.0)\"><g style=\"fill: #0000ff;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.0, 0.0)\"><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.52;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.0, 0.0)\"><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g></g><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 12.50005, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 15.00005, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -1.5, -0.0)\"><g><g><g><g><g><g><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g></g><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 1.0000499999999999)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(0.0, -1.0, 1.0, 0.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 2.0000999999999998)\"><g><g><g><g><g><g><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -5e-05, -0.25005)\"><g><g><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.25)\"><g style=\"fill: #000000;stroke: black;stroke-width: 0.0;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><text style=\"text-align:center; text-anchor:middle; dominant-baseline:middle;\n",
-       "                      font-family:sans-serif; font-weight: bold;\n",
-       "                      font-size:0.5px;\n",
-       "                      vector-effect: non-scaling-stroke;\" transform=\"translate(-5e-05, 0)\">target</text></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.5001)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g></g><g/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.50005, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.50005, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -2.0, -0.0)\"><g><g><g><g><g><g><g><g><g style=\"fill: #0000ff;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.0, 0.0)\"><g style=\"fill: #0000ff;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.0, 0.0)\"><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 4.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g></g><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 6.50005, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 9.50005, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -2.0, -0.0)\"><g><g><g><g><g><g><g><g><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.5800000000000001;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.0, 0.0)\"><g style=\"fill: #0000ff;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.0, 0.0)\"><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.52;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.0, 0.0)\"><g style=\"fill: #ffa500;stroke: black;stroke-width: 1.5;fill-opacity: 0.46;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 3.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 4.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g></g><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 12.50005, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 15.00005, 0.0)\"><g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, -1.0, -0.0)\"><g><g><g><g><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 1.5, 0.0)\"><g transform=\"matrix(1.0, -0.0, 0.0, 1.0, 0.0, 0.0)\"><g/></g></g></g><g transform=\"matrix(1.0, 0.0, 0.0, 1.0, 2.0, 0.0)\"><g style=\"stroke: black;stroke-width: 1.5;\" transform=\"matrix(1.0, 0.0, 0.0, 1.0, 0.0, 0.0)\"><rect height=\"1\" style=\"vector-effect: non-scaling-stroke;\" width=\"1\" x=\"-0.5\" y=\"-0.5\"/></g></g></g></g><g/></g></g></g></g></g></g></g></g><g/></g></g></g></g><g/></g></g></g></g></svg>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.SVG object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "def pad_to_spec(a, out):\n",
-    "    for i in range(min(len(out), len(a))):\n",
-    "        out[i] = a[i]\n",
-    "\n",
-    "\n",
-    "def pad_to(a: TT[\"i\"], i: int, j: int) -> TT[\"j\"]:\n",
-    "    raise NotImplementedError\n",
-    "\n",
-    "\n",
-    "test_pad_to = make_test(\"pad_to\", pad_to, pad_to_spec, add_sizes=[\"i\", \"j\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "f8e5aee3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-07-13T00:15:31.166060Z",
-     "iopub.status.busy": "2022-07-13T00:15:31.165749Z",
-     "iopub.status.idle": "2022-07-13T00:15:31.169131Z",
-     "shell.execute_reply": "2022-07-13T00:15:31.168580Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# run_test(test_pad_to)"
    ]
   },
   {


### PR DESCRIPTION
pad_to function can make easier implementation of the compress function, it took me a day to find out. I suggest to switch the order of pad_to with compress function. 
I have also edited some of the cells in the end, because the styling wasn't the same as in the rest of the notebook,