### PR TITLE
avoid cryptic SVG rendering error / check that solution output is actually a tensor

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -179,7 +179,7 @@ def make_test(name, problem, problem_spec, add_sizes=[], constraint=lambda d: d)
         for size in add_sizes:
             del example[size]
         example["target"] = tensor(out)
-        if yours is not None:
+        if torch.is_tensor(yours) and yours.ndim > 0:
             example["yours"] = yours 
         examples.append(example)
         


### PR DESCRIPTION
**The problem:** If the user's solution to a puzzle is a rank-0 tensor (eg, `tensor(6)`), running `make_test` results in a cryptic TypeError many levels deep in the SVG-rendering code. This is documented pretty well by @ikamensh in #23.

**This solution:** This change adds a check, `torch.is_tensor(yours) and yours.ndim > 0`, before adding the user's solution output to the data to be rendered to the SVG.

**Caveats:** The solution checker seems to accept `tensor(6)`, `tensor([6])`, `tensor([[6]])`, equally. Before this change, the SVG-rendering code would error out before solution checker ran, so you could call that "failing". I don't completely understand the solution-checking code and I'm not sure whether that is intended behavior.

Hopefully this makes sense. I'm happy to discuss it or make changes if you'd like. Thanks in advance!