### PR TITLE
Remove `i` argument in `flip` boilerplate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,11 +410,11 @@ def flip_spec(a, out):
     for i in range(len(out)):
         out[i] = a[len(out) - i - 1]
         
-def flip(a: TT["i"], i: int) -> TT["i"]:
+def flip(a: TT["i"]) -> TT["i"]:
     raise NotImplementedError
 
 
-test_flip = make_test("flip", flip, flip_spec, add_sizes=["i"])
+test_flip = make_test("flip", flip, flip_spec)
 ```
 
 


### PR DESCRIPTION
`flip`s spec function doesn't specify a second argument `i`, and the same is true for `np.flip`, which has a second argument to specify the dim to be flipped and it isn't applicable here since the requirement is only to support vectors.

So either the flip boilerplate code has to be updated, or the spec function. I can change other files if necessary.